### PR TITLE
refactor(types): use unknown instead of any

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,24 +7,24 @@
  * file that was distributed with this source code.
  */
 
-export type NextFn = () => Promise<any> | any
+export type NextFn = () => Promise<unknown> | unknown
 
 /**
  * Final handler is called when the entire chain has been
  * executed successfully.
  */
-export type FinalHandler = () => Promise<any>
+export type FinalHandler = () => Promise<unknown>
 
 /**
- * Error handler is called any method in the pipeline raises
+ * Error handler is called any method in the pipeline that raises
  * an exception
  */
-export type ErrorHandler = (error: any) => Promise<any>
+export type ErrorHandler = (error: unknown) => Promise<unknown>
 
 /**
  * The executor function that invokes the middleware
  */
-export type Executor<MiddlewareFn extends any> = (
+export type Executor<MiddlewareFn extends unknown> = (
   middleware: MiddlewareFn,
   next: NextFn
-) => Promise<any>
+) => Promise<unknown>


### PR DESCRIPTION
Hey! 👋🏻 

This PR removes the usage of `any` and replaces it with `unknown` instead.

This is needed to avoid Adonis' middleware being marked as an error with `@typescript-eslint/no-unsafe-return` rule.

```
\app\middleware\container_bindings_middleware.ts
  17:3  error  Unsafe return of an `any` typed value  @typescript-eslint/no-unsafe-return
```